### PR TITLE
Switched default roulette protocol version to v1

### DIFF
--- a/QuizRouletteServer-build/QuizRouletteServer-code/src/main/java/ch/heigvd/res/labs/roulette/QuizRouletteServer.java
+++ b/QuizRouletteServer-build/QuizRouletteServer-code/src/main/java/ch/heigvd/res/labs/roulette/QuizRouletteServer.java
@@ -25,7 +25,7 @@ public class QuizRouletteServer {
    */
   public static void main(String[] args) throws IOException {
     System.setProperty("java.util.logging.SimpleFormatter.format", "%5$s %n");
-    RouletteServer server = new RouletteServer(RouletteV1Protocol.DEFAULT_PORT, RouletteV2Protocol.VERSION);
+    RouletteServer server = new RouletteServer(RouletteV1Protocol.DEFAULT_PORT, RouletteV1Protocol.VERSION);
     try {
       server.startServer();
     } catch (IOException ex) {


### PR DESCRIPTION
Following the current instructions, the server crashes because the protocol version is v2 by default and the v2 client handler is not implemented.
